### PR TITLE
Document id is not always present

### DIFF
--- a/lib/services/document.js
+++ b/lib/services/document.js
@@ -175,7 +175,7 @@ module.exports.setDocumentState = function (resource, filter, fromState, toState
           }
 
           resolve({
-            id: document._id.toString(),
+            doc: document,
             state: {
               from: fromState,
               to: toState


### PR DESCRIPTION
Depending on the mongoDB version, document._id is not present. Plus it is more useful to send the document entirely than only the id (which is obviously known by the client because it is in the URL)